### PR TITLE
chore: integrate Prometheus for metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+## Running Prometheus with Docker (Windows - Git Bash)
+
+To start Prometheus using Docker with your local `prometheus.yml` config file, run the following command:
+
+```bash
+docker run -d -p 9090:9090 \
+  -v "<repo_path>/monitoring/prometheus.yml:/etc/prometheus/prometheus.yml" \
+  --name prometheus \
+  prom/prometheus
+```
+
+- You can now access Prometheus UI at: http://localhost:9090
+
+**Note:**
+
+- Without the /metrics route, Prometheus can't scrape your application — so your dashboards would be empty.
+- Use forward slashes `/` in the volume path on Git Bash to avoid issues.
+- Adjust `"<repo_path>"` to where the repo is added in the system.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,6 +18,7 @@
         "passport": "^0.5.3",
         "passport-google-oauth20": "^2.0.0",
         "passport-local": "^1.0.0",
+        "prom-client": "^15.1.3",
         "redis": "^5.1.0",
         "uuid": "^11.0.3",
         "zod": "^3.24.1"
@@ -105,6 +106,15 @@
       "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@redis/bloom": {
@@ -629,6 +639,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -2103,6 +2119,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -2563,6 +2592,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/to-regex-range": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
     "passport": "^0.5.3",
     "passport-google-oauth20": "^2.0.0",
     "passport-local": "^1.0.0",
+    "prom-client": "^15.1.3",
     "redis": "^5.1.0",
     "uuid": "^11.0.3",
     "zod": "^3.24.1"

--- a/backend/src/config/metrics.config.ts
+++ b/backend/src/config/metrics.config.ts
@@ -1,0 +1,17 @@
+import client from "prom-client";
+
+// Create a Registry to register the metrics
+const register = new client.Registry();
+
+// Enable default metrics (CPU, memory, event loop lag, etc.)
+client.collectDefaultMetrics({ register });
+
+// Custom metric (e.g., HTTP request duration)
+const httpRequestDuration = new client.Histogram({
+  name: "http_request_duration_seconds",
+  help: "Duration of HTTP requests in seconds",
+  labelNames: ["method", "route", "status_code"],
+});
+register.registerMetric(httpRequestDuration);
+
+export { register, httpRequestDuration };

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,21 +3,28 @@ import express, { NextFunction, Request, Response } from "express";
 
 import cors from "cors";
 import session from "cookie-session";
+import passport from "passport";
 import { config } from "./config/app.config";
 import connectDatabase from "./config/database.config";
 import { HTTPSTATUS } from "./config/http.config";
-import { errorHandler } from "./middlewares/errorHandler.middleware";
-import { asyncHandler } from "./middlewares/asyncHandler.middleware";
+import "./config/passport.config";
 import { redisClient, connectRedis } from "./config/redis.config";
 
-import "./config/passport.config";
-import passport from "passport";
-import authRoutes from "./routes/auth.route";
-import userRoutes from "./routes/user.route";
+import { asyncHandler } from "./middlewares/asyncHandler.middleware";
+import { errorHandler } from "./middlewares/errorHandler.middleware";
 import { isAuthenticated } from "./middlewares/isAuthenticated.middleware";
-import workspaceRoutes from "./routes/workspace.route";
+
+// metrics, to enable uncomment
+/*
+import { register } from "./config/metrics.config";
+import { prometheusMiddleware } from "./middlewares/prometheus.middleware";
+*/
+
+import authRoutes from "./routes/auth.route";
 import memberRoutes from "./routes/member.route";
 import projectRoutes from "./routes/project.route";
+import userRoutes from "./routes/user.route";
+import workspaceRoutes from "./routes/workspace.route";
 
 const BASE_PATH = config.BASE_PATH;
 const REDIS_DEFAULT_TTL = 3600;
@@ -48,6 +55,9 @@ app.use(
   })
 );
 
+//metrics middleware uncomment to enable
+//app.use(prometheusMiddleware);
+
 // To test redis route
 app.get(
   `/test`,
@@ -77,6 +87,13 @@ app.get(
     });
   })
 );
+
+/*  endpoint to expose metrics to Prometheus
+app.get("/metrics", async (req, res) => {
+  res.set("Content-Type", register.contentType);
+  res.send(await register.metrics());
+});
+*/
 
 app.use(`${BASE_PATH}/auth`, authRoutes);
 app.use(`${BASE_PATH}/member`, isAuthenticated, memberRoutes);

--- a/backend/src/middlewares/prometheus.middleware.ts
+++ b/backend/src/middlewares/prometheus.middleware.ts
@@ -1,0 +1,24 @@
+// src/middlewares/prometheus.middleware.ts
+import { Request, Response, NextFunction } from "express";
+import { httpRequestDuration } from "../config/metrics.config";
+
+export const prometheusMiddleware = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  // Start timer with labels method and route (use path as fallback)
+  const end = httpRequestDuration.startTimer({
+    method: req.method,
+    route: req.route?.path || req.path,
+  });
+
+  res.on("finish", () => {
+    const statusCode = res.statusCode.toString();
+
+    // Stop timer and record status_code label
+    end({ status_code: statusCode });
+  });
+
+  next();
+};

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'mern-backend'
+    static_configs:
+      - targets: ['host.docker.internal:8000']


### PR DESCRIPTION
The middleware (which tracks metrics like HTTP durations) collects and records data into Prometheus-compatible metrics objects (e.g., histograms or counters).

But Prometheus doesn't push data — it pulls it by scraping your /metrics endpoint.